### PR TITLE
增加map_realpath参数及对应功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Type: `String`
 Destination of moudle files which should to build.
 
 
+#### options.map_realpath
+Type: `bool`
+
+map里面的路径是否为实际路径，默认实际路径。
+
+
 ### Usage Examples
 
 
@@ -84,7 +90,8 @@ grunt.initConfig({
   hashmap: {
     tests: {
         options: {
-            build_dest: 'tmp/.build'
+            build_dest: 'tmp/.build',
+            map_build:false
         },
         files: [
           {
@@ -102,6 +109,10 @@ grunt.initConfig({
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
+**May 14th, 2014** `0.2.2`
+
+增加map_build参数，为false则map里面直接使用seajs的id，其他值或者不设置则为原来版本的样子。
+
 **Apr 15th, 2014** `0.2.1`
 
 Upgrade dependencies to newest version, minor fix.

--- a/tasks/hashmap.js
+++ b/tasks/hashmap.js
@@ -14,96 +14,101 @@ var fs = require('fs');
 
 module.exports = function(grunt) {
 
-    // Please see the Grunt documentation for more information regarding task
-    // creation: http://gruntjs.com/creating-tasks
+	// Please see the Grunt documentation for more information regarding task
+	// creation: http://gruntjs.com/creating-tasks
 
-    grunt.registerMultiTask('hashmap', 'Your task description goes here.', function() {
-        // Merge task-specific and/or target-specific options with these defaults.
-        var options = this.options({
-            algorithm: 'md5',
-            encoding: 'utf8',
-            map_tpl: path.join(__dirname, 'map.tpl'),
-            MAP_BLOCK_RE: /\/\*map start\*\/[\s\S]*\/\*map end\*\//,
-            MAP_FILE_RE: /[^"]+\?\w+/g,
-        });
+	grunt.registerMultiTask('hashmap', 'Your task description goes here.', function() {
+		// Merge task-specific and/or target-specific options with these defaults.
+		var options = this.options({
+			algorithm: 'md5',
+			encoding: 'utf8',
+			map_tpl: path.join(__dirname, 'map.tpl'),
+			MAP_BLOCK_RE: /\/\*map start\*\/[\s\S]*\/\*map end\*\//,
+			MAP_FILE_RE: /[^"]+\?\w+/g,
+		});
 
-        var done = this.async();
+		var done = this.async();
 
-        // Iterate over all specified file groups.
-        this.files.forEach(function(f) {
-            if (!f.dest) {
-                grunt.log.error('Dest map file does not specified');
-                return false;
-            }
-            var encoding = options.encoding;
-            var cwd = f.cwd;
-            var mapping = [];
-            var originMapping = {};
-            var dest = f.dest;
-            var MAP_TPL = grunt.file.read(options.map_tpl);
+		// Iterate over all specified file groups.
+		this.files.forEach(function(f) {
+			if (!f.dest) {
+				grunt.log.error('Dest map file does not specified');
+				return false;
+			}
+			var encoding = options.encoding;
+			var cwd = f.cwd;
+			var mapping = [];
+			var originMapping = {};
+			var dest = f.dest;
+			var MAP_TPL = grunt.file.read(options.map_tpl);
 
-            if (options.build_dest && grunt.file.exists(dest)) {
-                var mapContents = fs.readFileSync(dest, encoding);
-                var hashArr = mapContents.match(options.MAP_FILE_RE);
-                if(hashArr !== null){
-                    for (var i = hashArr.length - 1; i >= 0; i--) {
-                        var item = hashArr[i].split('?');
-                        originMapping[item[0]] = item[1];
-                    }
-                }
-            }
+			if (options.build_dest && grunt.file.exists(dest)) {
+				var mapContents = fs.readFileSync(dest, encoding);
+				var hashArr = mapContents.match(options.MAP_FILE_RE);
+				if (hashArr !== null) {
+					for (var i = hashArr.length - 1; i >= 0; i--) {
+						var item = hashArr[i].split('?');
+						originMapping[item[0]] = item[1];
+					}
+				}
+			}
 
-            var src = f.src.filter(function(filepath) {
-                filepath = realpath(filepath);
-                // Warn on and remove invalid source files (if nonull was set).
-                if (!grunt.file.exists(filepath)) {
-                    grunt.log.warn('Source file "' + filepath + '" not found.');
-                    return false;
-                } else {
-                    return true;
-                }
-            });
+			var src = f.src.filter(function(filepath) {
+				filepath = realpath(filepath);
+				// Warn on and remove invalid source files (if nonull was set).
+				if (!grunt.file.exists(filepath)) {
+					grunt.log.warn('Source file "' + filepath + '" not found.');
+					return false;
+				} else {
+					return true;
+				}
+			});
 
-            src.forEach(function(filepath) {
-                var r = realpath(filepath), d;
+			src.forEach(function(filepath) {
+				var r = realpath(filepath),
+					d;
+				var shasum = crypto.createHash(options.algorithm);
+				var s = fs.ReadStream(r);
+				s.on('data', function(data) {
+					shasum.update(data, encoding);
+				});
+				s.on('end', function() {
+					d = shasum.digest('hex');
+					var _r = (options.map_realpath === false ? filepath : r);
+					mapping.push([_r, _r + '?' + d]);
 
-                var shasum = crypto.createHash(options.algorithm);
-                var s = fs.ReadStream(r);
-                s.on('data', function(data) {
-                    shasum.update(data, encoding);
-                });
-                s.on('end', function() {
-                    d = shasum.digest('hex');
-                    mapping.push([r, r + '?' + d]);
+					if (options.build_dest && d !== originMapping[r]) {
+						grunt.file.copy(r, path.join(options.build_dest, filepath));
+						grunt.log.oklns('File: "' + r + '"" copy to build dest.');
+					}
 
-                    if(options.build_dest && d !== originMapping[r]){
-                        grunt.file.copy(r, path.join(options.build_dest, filepath));
-                        grunt.log.oklns('File: "' + r + '"" copy to build dest.');
-                    }
+					if (mapping.length === src.length) {
+						output();
+					}
+				});
+			});
 
-                    if(mapping.length === src.length){
-                        output();
-                    }
-                });
-            });
+			function realpath(filepath) {
+				return cwd ? path.join(cwd, filepath) : filepath;
+			}
 
-            function realpath(filepath) {
-                return cwd ? path.join(cwd, filepath) : filepath;
-            }
+			function output() {
+				var config = '';
+				if (grunt.file.exists(dest)) {
+					config = grunt.file.read(dest);
+				}
+				config = config.replace(options.MAP_BLOCK_RE, '').trim();
 
-            function output(){
-                var config = '';
-                if(grunt.file.exists(dest)){
-                    config = grunt.file.read(dest);
-                }
-                config = config.replace(options.MAP_BLOCK_RE, '').trim();
+				config = grunt.template.process(MAP_TPL, {
+					data: {
+						mapArray: JSON.stringify(mapping, 'null', '\t')
+					}
+				}) + '\n' + config;
+				grunt.file.write(dest, config);
 
-                config = grunt.template.process(MAP_TPL, {data : {mapArray : JSON.stringify(mapping, 'null', '\t')}}) + '\n' + config;
-                grunt.file.write(dest, config);
-
-                grunt.log.oklns('Hash map config write to file: "' + dest + '".');
-                done();
-            }
-        });
-    });
+				grunt.log.oklns('Hash map config write to file: "' + dest + '".');
+				done();
+			}
+		});
+	});
 };


### PR DESCRIPTION
在构建seajs的时候生成的map的路径在cwd有内容的时候会追加上文件所在的实际路径，问题是在构建过程中这个时候文件是存放在.build临时文件夹里的，但是map里面的路径会把.build也加上，而且单个斜杠 / 会变成 双反斜杠 \\ ，这样子生成的map没有用。可能是我自己使用有问题，不过没找到原因就自己修改这个来适应自己的需求了。

通过增加map_realpath参数来控制map里的地址是直接用transport提取出来的id还是实际路径。只有在设置了这个参数并且值为false的时候才有效，其他情况都和之前版本一致。
